### PR TITLE
Generate mesh previews by looking in children

### DIFF
--- a/addons/component_view/panel/Loaders.gd
+++ b/addons/component_view/panel/Loaders.gd
@@ -4,6 +4,21 @@ extends Node
 export var root_path = "res://assets/components/"
 var plugin
 
+
+func _find_mesh(node: Node):
+	if not node:
+		return null
+	var mesh = node.get("mesh")
+	if mesh:
+		return node.mesh
+	elif node.has_method("get_mesh"):
+		return node.get_mesh()
+	for item in node.get_children():
+		mesh = _find_mesh(item)
+		if mesh:
+			return mesh
+
+
 func load_all(plugin:EditorPlugin):
 	var datas = []
 	var collections = {}
@@ -19,13 +34,11 @@ func load_all(plugin:EditorPlugin):
 				#Map the individual items to their meshes.
 				for item in data_array:
 					if item.scene is PackedScene:
-							var root = item.scene.instance(PackedScene.GEN_EDIT_STATE_DISABLED) as Node
-							var mesh = root.get("mesh")
-							if mesh != null:
-								icon_map[item] = root.mesh
-							elif root.has_method("get_mesh"):
-								icon_map[item] = root.get_mesh()
-							root.queue_free()
+						var root = item.scene.instance(PackedScene.GEN_EDIT_STATE_DISABLED) as Node
+						var mesh = _find_mesh(root)
+						if mesh != null:
+							icon_map[item] = mesh
+						root.queue_free()
 
 				(collections[key] as Array).append_array(data_array)
 			pass


### PR DESCRIPTION
Fix #4.

From this wiki page I understand what was wrong: https://github.com/Frontrider/Godot-Scene-Browser/wiki/Asset-handling

This PR looks deeper inside each scene to find a mesh so we have something to preview.

Using [Kenney's city-kit-commercial](https://kenney.nl/assets/city-kit-commercial) and dumping all of the Models folder into `assets/components/` I now see this:

![image](https://user-images.githubusercontent.com/43559/208606501-774ef6f3-b183-486d-9579-70b48586f020.png)

So only GLTF and OBJ imports in a way that scene browser can see (I guess the others are just meshes and not scenes?) and GLTF now generates proper previews. Not sure why OBJ still doesn't work.

I kept the "get_mesh" function checker. Not sure if that's a godot builtin function or a way for Godot-Scene-Browser users to specify the mesh location?